### PR TITLE
Fix , and . errors by forcing .

### DIFF
--- a/PokemonGo.Haxton.Bot/Settings/Settings.cs
+++ b/PokemonGo.Haxton.Bot/Settings/Settings.cs
@@ -2,6 +2,7 @@
 using PokemonGo.RocketAPI.Enums;
 using System;
 using System.Configuration;
+using System.Globalization;
 using System.IO;
 
 namespace PokemonGo.Haxton.Bot.Settings
@@ -12,8 +13,8 @@ namespace PokemonGo.Haxton.Bot.Settings
         {
             AuthType =
                 (AuthType)Enum.Parse(typeof(AuthType), ConfigurationManager.AppSettings["AccountType"]);
-            DefaultLatitude = Convert.ToDouble(ConfigurationManager.AppSettings["DefaultLatitude"]);
-            DefaultLongitude = Convert.ToDouble(ConfigurationManager.AppSettings["DefaultLongitude"]);
+            DefaultLatitude = Convert.ToDouble(ConfigurationManager.AppSettings["DefaultLatitude"], CultureInfo.GetCultureInfo("en-US").NumberFormat);
+            DefaultLongitude = Convert.ToDouble(ConfigurationManager.AppSettings["DefaultLongitude"], CultureInfo.GetCultureInfo("en-US").NumberFormat);
             DefaultAltitude = Convert.ToDouble(ConfigurationManager.AppSettings["DefaultAltitude"]);
             PtcUsername = ConfigurationManager.AppSettings["PtcUsername"];
             PtcPassword = ConfigurationManager.AppSettings["PtcPassword"];

--- a/PokemonGo.Haxton.Console/Program.cs
+++ b/PokemonGo.Haxton.Console/Program.cs
@@ -11,12 +11,12 @@ using PokemonGo.RocketAPI;
 using StructureMap;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 namespace PokemonGo.Haxton.Console
 {
     internal class Program
@@ -52,8 +52,8 @@ namespace PokemonGo.Haxton.Console
                     var split = input?.Split(',');
                     if (split != null)
                     {
-                        var x = double.Parse(split[0]);
-                        var y = double.Parse(split[1]);
+                        var x = double.Parse(split[0], CultureInfo.GetCultureInfo("en-US").NumberFormat);
+                        var y = double.Parse(split[1], CultureInfo.GetCultureInfo("en-US").NumberFormat);
                         foreach (var poGoSnipe in snipe)
                         {
                             poGoSnipe.AddNewSnipe(x, y);


### PR DESCRIPTION
Forcing c# to always parse a dot (.) as decimal separator
