### PR TITLE
Add delay to restart on exception

### DIFF
--- a/PokemonGo.Haxton.Console/Program.cs
+++ b/PokemonGo.Haxton.Console/Program.cs
@@ -122,6 +122,7 @@ namespace PokemonGo.Haxton.Console
                     catch (Exception ex)
                     {
                         logger.Fatal(ex, "Fatal error, attempting to restart");
+                        await Task.Delay(5000);
                     }
                 }
             }, _cancelToken.Token);


### PR DESCRIPTION
Add a little delay to restart on exception

Prevents hammering the login server when things aren't going as planned
