### PR TITLE
Fix issue with xbuild+mono

### DIFF
--- a/FeroxRev/PokemonGo.RocketAPI/PokemonGo.RocketAPI.csproj
+++ b/FeroxRev/PokemonGo.RocketAPI/PokemonGo.RocketAPI.csproj
@@ -54,8 +54,8 @@
       <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="POGOProtos, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\POGOProtos.1.3.0\lib\net45\POGOProtos.dll</HintPath>
+    <Reference Include="POGOProtos, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\POGOProtos.1.4.0\lib\net45\POGOProtos.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="S2Geometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/FeroxRev/PokemonGo.RocketAPI/PokemonGo.RocketAPI.csproj
+++ b/FeroxRev/PokemonGo.RocketAPI/PokemonGo.RocketAPI.csproj
@@ -55,7 +55,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="POGOProtos, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\POGOProtos.1.4.0\lib\net45\POGOProtos.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\POGOProtos.1.4.0\lib\net45\POGOProtos.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="S2Geometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/FeroxRev/PokemonGo.RocketAPI/Rpc/Encounter.cs
+++ b/FeroxRev/PokemonGo.RocketAPI/Rpc/Encounter.cs
@@ -34,7 +34,7 @@ namespace PokemonGo.RocketAPI.Rpc
             {
                 EncounterId = encounterId,
                 ItemId = itemId,
-                SpawnPointGuid = spawnPointGuid
+                SpawnPointId = spawnPointGuid
             };
             
             return await PostProtoPayload<Request, UseItemCaptureResponse>(RequestType.UseItemCapture, message);

--- a/FeroxRev/PokemonGo.RocketAPI/packages.config
+++ b/FeroxRev/PokemonGo.RocketAPI/packages.config
@@ -8,7 +8,7 @@
   <package id="GPSOAuthSharp" version="0.0.5" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="POGOProtos" version="1.3.0" targetFramework="net45" />
+  <package id="POGOProtos" version="1.4.0" targetFramework="net45" />
   <package id="S2Geometry" version="1.0.1" targetFramework="net45" />
   <package id="VarintBitConverter" version="1.0.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I changed the RocketAPI to also use a newer version of POGOProtos because it was updated in PokemonGo.Haxton.Bot and causing an issue when using xbuild and mono.
Fixes #78. 
